### PR TITLE
Fixes CKA and dCKA computation during batch aggregation

### DIFF
--- a/simtorch/similarity/cka.py
+++ b/simtorch/similarity/cka.py
@@ -72,6 +72,6 @@ class CKA(BaseSimilarity):
         self.sim_matrix = np.zeros_like(batch_cka_matrix)
         for mat in cka_matrices:
             self.sim_matrix += mat
-        self.sim_matrix /= len(batch_cka_matrix)
+        self.sim_matrix /= len(cka_matrices)
 
         return self.sim_matrix

--- a/simtorch/similarity/delta_cka.py
+++ b/simtorch/similarity/delta_cka.py
@@ -122,6 +122,6 @@ class DeltaCKA(BaseSimilarity):
         self.sim_matrix = np.zeros_like(batch_cka_matrix)
         for mat in cka_matrices:
             self.sim_matrix += mat
-        self.sim_matrix /= len(batch_cka_matrix)
+        self.sim_matrix /= len(cka_matrices)
 
         return self.sim_matrix


### PR DESCRIPTION
When aggregating the sim cka for each batch of input, we currently divide by the number of layers instead of the number of batches. 

This results in incorrect CKA, for example diagnoal is not 1 when we compute CKA between same network.

Before:
<img src="https://github.com/user-attachments/assets/d6fbc92c-37be-444f-a70b-f8c064a076ef" alt="image" width="400" height=auto/>

After: 
<img src="https://github.com/user-attachments/assets/bce95151-7940-4a81-9977-ce48c4a6ae14" alt="image" width="400" height=auto />

---
Hopefully this fixes #20 
